### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: windows-2019
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+
+    - name: Restore NuGet packages
+      run: nuget restore
+
+    - name: Build
+      run: msbuild /p:Configuration=Release /p:Platform=x64 /p:SourceLinkCreate=false
+
+    - name: Archive DCS-SR-OverlordBot
+      uses: actions/upload-artifact@v2
+      with:
+        name: DCS-SR-OverlordBot
+        path: DCS-SR-OverlordBot/bin/x64/Release
+
+    - name: Archive TaxiViewer
+      uses: actions/upload-artifact@v2
+      with:
+        name: TaxiViewer
+        path: TaxiViewer/bin/Release
+
+    - name: Setup VSTest
+      uses: Malcolmnixon/Setup-VSTest@v3
+
+    - name: VSTest RurouniJones-DCS-Airfields-Tests
+      run: VSTest.Console RurouniJones-DCS-Airfields-Tests\bin\Release\RurouniJones-DCS-Airfields-Tests.dll


### PR DESCRIPTION
Builds projects and runs test for every commit and pull request. The output of `DCS-SR-OverlordBot` and `TaxiViewer` can be downloaded as an artifact from each build.

The `DCS-SR-OverlordBot-Tests` is currently broken locally in Visual Studio as well and needs to be sorted before being added to the CI steps.