### PR TITLE
Allow minor spelling errors in group name

### DIFF
--- a/DCS-SR-OverlordBot-Tests/DCS-OverlordBot-Tests.csproj
+++ b/DCS-SR-OverlordBot-Tests/DCS-OverlordBot-Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Controllers\AwacsControllerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Util\GeospatialTests.cs" />
+    <Compile Include="Util\LevenshteinDistanceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/DCS-SR-OverlordBot-Tests/Util/LevenshteinDistanceTests.cs
+++ b/DCS-SR-OverlordBot-Tests/Util/LevenshteinDistanceTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace RurouniJones.DCS.OverlordBot.Util.Tests
+{
+    [TestClass]
+    class LevenshteinDistanceTests
+    {
+        [TestMethod]
+        public void WhenStringsEqualReturnZero()
+        {
+            Assert.IsTrue(LevenshteinDistance.Calculate("RurouniJones", "RurouniJones") == 0);
+        }
+
+        [TestMethod]
+        public void WhenOneStringEmptyReturnLengthOfTheOther()
+        {
+            Assert.IsTrue(LevenshteinDistance.Calculate("RurouniJones", "") == "RurouniJones".Length);
+            Assert.IsTrue(LevenshteinDistance.Calculate("", "RurouniJones") == "RurouniJones".Length);
+        }
+
+        [TestMethod]
+        public void WhenStringsSimilarReturnLevenshteinDistance()
+        {
+            Assert.IsTrue(LevenshteinDistance.Calculate("Kodiak", "Kodak") == 1);
+            Assert.IsTrue(LevenshteinDistance.Calculate("Ram", "Raman") == 2);
+            Assert.IsTrue(LevenshteinDistance.Calculate("Mama", "Mom") == 2);
+            Assert.IsTrue(LevenshteinDistance.Calculate("imax", "volmax") == 3);
+        }
+    }
+}

--- a/DCS-SR-OverlordBot/DCS-OverlordBot.csproj
+++ b/DCS-SR-OverlordBot/DCS-OverlordBot.csproj
@@ -312,6 +312,7 @@
     <Compile Include="RadioCalls\LuisModels\LuisEntity.cs" />
     <Compile Include="RadioCalls\LuisModels\LuisResponse.cs" />
     <Compile Include="Util\AirfieldUpdater.cs" />
+    <Compile Include="Util\LevenshteinDistance.cs" />
     <Compile Include="Util\Geospatial.cs" />
     <Compile Include="Controllers\WarningRadiusChecker.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/DCS-SR-OverlordBot/RadioCalls/BaseRadioCall.cs
+++ b/DCS-SR-OverlordBot/RadioCalls/BaseRadioCall.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RurouniJones.DCS.OverlordBot.GameState;
 using RurouniJones.DCS.OverlordBot.RadioCalls.LuisModels;
+using RurouniJones.DCS.OverlordBot.Util;
 
 namespace RurouniJones.DCS.OverlordBot.RadioCalls
 {
@@ -139,6 +140,10 @@ namespace RurouniJones.DCS.OverlordBot.RadioCalls
             }
 
             var groupEntity = entities.Find(x => x.Entity.Equals(group));
+            if (groupEntity is null)
+            {
+                groupEntity = entities.Find(x => LevenshteinDistance.Calculate(x, group) == 1);
+            }
             if (groupEntity?.Resolution?.Values?.Count > 0)
             {
                 group = groupEntity.Resolution.Values[0];

--- a/DCS-SR-OverlordBot/RadioCalls/BaseRadioCall.cs
+++ b/DCS-SR-OverlordBot/RadioCalls/BaseRadioCall.cs
@@ -142,7 +142,7 @@ namespace RurouniJones.DCS.OverlordBot.RadioCalls
             var groupEntity = entities.Find(x => x.Entity.Equals(group));
             if (groupEntity is null)
             {
-                groupEntity = entities.Find(x => LevenshteinDistance.Calculate(x, group) == 1);
+                groupEntity = entities.Find(x => LevenshteinDistance.Calculate(x.Entity, group) == 1);
             }
             if (groupEntity?.Resolution?.Values?.Count > 0)
             {

--- a/DCS-SR-OverlordBot/Util/LevenshteinDistance.cs
+++ b/DCS-SR-OverlordBot/Util/LevenshteinDistance.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RurouniJones.DCS.OverlordBot.Util
+{
+    /// <summary>
+    /// Implementation of Levenshtein Distance algorithm, taken from https://gist.github.com/Davidblkx/e12ab0bb2aff7fd8072632b396538560
+    /// </summary>
+    public static class LevenshteinDistance
+    {
+        /// <summary>
+        ///     Calculate the difference between 2 strings using the Levenshtein distance algorithm
+        /// </summary>
+        /// <param name="source1">First string</param>
+        /// <param name="source2">Second string</param>
+        /// <returns></returns>
+        public static int Calculate(string source1, string source2) //O(n*m)
+        {
+            var source1Length = source1.Length;
+            var source2Length = source2.Length;
+
+            var matrix = new int[source1Length + 1, source2Length + 1];
+
+            // First calculation, if one entry is empty return full length
+            if (source1Length == 0)
+                return source2Length;
+
+            if (source2Length == 0)
+                return source1Length;
+
+            // Initialization of matrix with row size source1Length and columns size source2Length
+            for (var i = 0; i <= source1Length; matrix[i, 0] = i++) { }
+            for (var j = 0; j <= source2Length; matrix[0, j] = j++) { }
+
+            // Calculate rows and collumns distances
+            for (var i = 1; i <= source1Length; i++)
+            {
+                for (var j = 1; j <= source2Length; j++)
+                {
+                    var cost = (source2[j - 1] == source1[i - 1]) ? 0 : 1;
+
+                    matrix[i, j] = Math.Min(
+                        Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
+                        matrix[i - 1, j - 1] + cost);
+                }
+            }
+            // return result
+            return matrix[source1Length, source2Length];
+        }
+
+        static void Main()
+        {
+            Console.WriteLine(Calculate("climax", "volmax"));
+            Console.WriteLine(Calculate("Ram", "Raman"));
+            Console.WriteLine(Calculate("Mama", "Mom"));
+
+
+        }
+    }
+}


### PR DESCRIPTION
Yesterday I flew as Kodiak 1-1, once the bot recognized my call as from Kodak 1-1, there was no such player present on the server.

With this PR, if there is no Kodak 1-1, the bot should recognize me as the caller (provided I made the change in the right place). I did not make the acceptable distance as configurable as I don't know where configuration is stored and/or how it is accessed - distance of 1 is currently hardcoded in this PR.

Disclaimer: I am not a professional C# developer and last time I used VS was almost 10 years ago - I couldn't set it up to build the solution completely, and thus couldn't run the tests - please let me know if this needs some fixes.

If you feel like this feature is not welcome in the repo, please decline the PR.